### PR TITLE
Add ability to use short_title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10507,9 +10507,9 @@
       "dev": true
     },
     "sartography-workflow-lib": {
-      "version": "0.0.408",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.408.tgz",
-      "integrity": "sha512-esf6ZkTP9jGb+3bMb3OaBPEl3Hlwer4S9uWYFgZILXctynEKA8B0WkuTCMU44ToSUa23yljiSa9qprZIUXmWuw=="
+      "version": "0.0.413",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.413.tgz",
+      "integrity": "sha512-GMTwsqppIezM9oOBDtFGRYGJL6FRyPD+/g7f3qZyfq78Ou3gZwLHB86jcUE1QB6cjuzs5hYNJ/BHJ+Nkd8wC2w=="
     },
     "sass": {
       "version": "1.26.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ngx-page-scroll-core": "^7.0.0",
     "rfdc": "^1.1.4",
     "rxjs": "~6.5.4",
-    "sartography-workflow-lib": "0.0.408",
+    "sartography-workflow-lib": "0.0.413",
     "timeago.js": "^4.0.2",
     "ts-md5": "^1.2.7",
     "tslib": "^1.13.0",

--- a/src/app/_util/shrink.ts
+++ b/src/app/_util/shrink.ts
@@ -1,0 +1,12 @@
+
+
+
+export const shrink = (len: number, title: string, shortTitle?: string) :string => {
+  if ((shortTitle !== undefined) && (shortTitle !== null)){
+    title = shortTitle;
+  }
+  if (title.length > len){
+    return title.substr(0,len - 4) + ' ...';
+  }
+  return title;
+}

--- a/src/app/studies-dashboard/studies-dashboard.component.html
+++ b/src/app/studies-dashboard/studies-dashboard.component.html
@@ -39,7 +39,7 @@
 
       <ng-container matColumnDef="study.title">
         <th *matHeaderCellDef mat-header-cell mat-sort-header> Study</th>
-        <td *matCellDef="let approval" mat-cell title="{{approval.study.title}}"> {{shrink(60,approval.study.title)}} </td>
+        <td *matCellDef="let approval" mat-cell title="{{approval.study.title}}"> {{shrink(60,approval.study.title,approval.study.short_title)}} </td>
       </ng-container>
 
       <ng-container matColumnDef="workflow.category_display_name">
@@ -115,7 +115,7 @@
 
         <ng-container matColumnDef="title">
           <th *matHeaderCellDef mat-header-cell mat-sort-header id="col_study_title"> Study Title</th>
-          <td *matCellDef="let study" class="study-blue" mat-cell title="{{study.title}}"> {{shrink(120,study.title)}} </td>
+          <td *matCellDef="let study" class="study-blue" mat-cell title="{{study.title}}"> {{shrink(120,study.title,study.short_title)}} </td>
         </ng-container>
 
         <ng-container matColumnDef="status">

--- a/src/app/studies-dashboard/studies-dashboard.component.ts
+++ b/src/app/studies-dashboard/studies-dashboard.component.ts
@@ -13,6 +13,7 @@ import {MatButtonToggleChange} from '@angular/material/button-toggle';
 import {FormlyFieldConfig} from '@ngx-formly/core';
 import {MatPaginator} from '@angular/material/paginator';
 import {MatSort} from '@angular/material/sort';
+import { shrink } from '../_util/shrink';
 
 enum IrbHsrStatus {
   NOT_SUBMITTED = 'Not Submitted',
@@ -41,6 +42,7 @@ export class StudiesDashboardComponent implements OnInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
   currentTab = 0;
+  shrink = shrink;
   displayedColumns: string[] = [
     'id',
     'title',
@@ -165,12 +167,6 @@ export class StudiesDashboardComponent implements OnInit {
     this.currentTab = currentTab
   }
 
-  shrink(len: number, title: string){
-    if (title.length > len){
-      return title.substr(0,len - 4) + ' ...';
-    }
-    return title;
-  }
 
   studyStatusDisplayType(study: Study) {
     if (this.isNewStudy(study)) { return StudyStatusDisplayType.NEW;}

--- a/src/app/study/study.component.html
+++ b/src/app/study/study.component.html
@@ -11,7 +11,7 @@
     </button>
     <mat-divider vertical></mat-divider>
     <div class="study-metadata">
-      <h1 title="{{study.title}}" class="study-metadata-title">{{shrink(160,study.title)}}</h1>
+      <h1 title="{{study.title}}" class="study-metadata-title">{{shrink(160,study.title,study.short_title)}}</h1>
       <dl fxLayout="row">
         <dt>ID:</dt>
         <dd>{{study.id}}</dd>

--- a/src/app/study/study.component.ts
+++ b/src/app/study/study.component.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
+import {shrink} from '../_util/shrink'
 import {
   ApiService,
   isNumberDefined,
@@ -23,6 +24,7 @@ export class StudyComponent implements OnInit {
   selectedCategory: WorkflowSpecCategory;
   selectedWorkflowId: number;
   selectedWorkflow: WorkflowStats;
+  shrink = shrink;
 
   constructor(
     private route: ActivatedRoute,
@@ -39,15 +41,6 @@ export class StudyComponent implements OnInit {
   get isWorkflowSelected(): boolean {
     return isNumberDefined(this.selectedWorkflowId);
   }
-
-  shrink(len: number, title: string){
-    if (title.length > len){
-      return title.substr(0,len - 4) + ' ...';
-    }
-    return title;
-  }
-
-
 
   ngOnInit() {
   }


### PR DESCRIPTION
In any place that it previously used a shortend regular title, we use the short_title if it exists, and use the shortened long title if it does not - short_title is also shortened if it is too long to fit -

All hovers show the long/ original title name.

Requires branch 220-short-study-name on cr-connect-workflow