### PR TITLE
Cleaning up a duplicate model, we had a WorkflowStats and a WorkflowM…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10621,9 +10621,9 @@
       "dev": true
     },
     "sartography-workflow-lib": {
-      "version": "0.0.442",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.442.tgz",
-      "integrity": "sha512-YKy7lLzsFITGti5vWYMzGL1V2a7IkP9DC+LDMbg6ePL+dfVCKlO5gfxm/pffQZIp/IhsvU5+C+ITW6CvgzE9uA=="
+      "version": "0.0.447",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.447.tgz",
+      "integrity": "sha512-xGBS1YQbXKj3O3I8bK58m7D2NApUpZUuzE3FxLTjS52Q1FL6Hgw2GY8urTJ/BF0a4ROEIHUaPm/4BN9yuzx33w=="
     },
     "sass": {
       "version": "1.26.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ngx-page-scroll-core": "^7.0.0",
     "rfdc": "^1.1.4",
     "rxjs": "~6.5.4",
-    "sartography-workflow-lib": "0.0.442",
+    "sartography-workflow-lib": "0.0.447",
     "timeago.js": "^4.0.2",
     "ts-md5": "^1.2.7",
     "tslib": "^1.13.0",

--- a/src/app/_util/nav-item.ts
+++ b/src/app/_util/nav-item.ts
@@ -1,7 +1,7 @@
-import {NavItemType, WorkflowNavItem, WorkflowState, WorkflowStats, WorkflowTaskState} from 'sartography-workflow-lib';
+import {NavItemType, WorkflowNavItem, WorkflowState, WorkflowMetadata, WorkflowTaskState} from 'sartography-workflow-lib';
 
 
-export const shouldDisplayWorkflow = (workflowListItem: WorkflowStats): boolean => {
+export const shouldDisplayWorkflow = (workflowListItem: WorkflowMetadata): boolean => {
   const hideTypes = [
     // removed disabled state per Alex - we need to display them and show them as being disabled instead.
     WorkflowState.HIDDEN,
@@ -11,14 +11,8 @@ export const shouldDisplayWorkflow = (workflowListItem: WorkflowStats): boolean 
     workflowListItem.state &&
     !hideTypes.includes(workflowListItem.state)
   );
-}
+};
 
-const groupTypes = [
-  NavItemType.SEQUENCE_FLOW,
-  NavItemType.EXCLUSIVE_GATEWAY,
-  NavItemType.PARALLEL_GATEWAY,
-  NavItemType.CALL_ACTIVITY,
-]
 const userTypes = [
   NavItemType.USER_TASK,
   NavItemType.MANUAL_TASK,
@@ -50,4 +44,4 @@ export const shouldDisableNavItem = (navItem: WorkflowNavItem): boolean => {
     WorkflowTaskState.FUTURE
   ];
   return (disableTypes.includes(navItem.state) || navItem.spec_type !== NavItemType.USER_TASK)
-}
+};

--- a/src/app/category/category.component.ts
+++ b/src/app/category/category.component.ts
@@ -5,7 +5,7 @@ import {
   Workflow,
   WorkflowNavItem,
   WorkflowSpecCategory,
-  WorkflowStats,
+  WorkflowMetadata,
   WorkflowStatus,
   WorkflowTaskState
 } from 'sartography-workflow-lib';
@@ -36,7 +36,7 @@ export class CategoryComponent implements OnInit {
     }
   }
 
-  get workflowsToDisplay(): WorkflowStats[] {
+  get workflowsToDisplay(): WorkflowMetadata[] {
     if (this.category && this.category.workflows && this.category.workflows.length > 0) {
       return this.category.workflows.filter(wf => shouldDisplayWorkflow(wf));
     } else {
@@ -48,7 +48,7 @@ export class CategoryComponent implements OnInit {
     this.loadWorkflow();
   }
 
-  isWorkflowComplete(workflow: WorkflowStats): boolean {
+  isWorkflowComplete(workflow: WorkflowMetadata): boolean {
     return workflow.status === WorkflowStatus.COMPLETE;
   }
 

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -15,7 +15,7 @@
             *ngFor="let workflowListItem of workflowsToShow(cat.workflows)"
             [ngClass]="'workflow-list-item workflow_status--' + workflowListItem.status + ' workflow_state--' + workflowListItem.state"
             >
-            <span title="{{workflowListItem.message}}">
+            <span title="{{workflowListItem.state_message}}">
             <div
               mat-line
               fxLayout="row"
@@ -27,8 +27,7 @@
               [ngClass]="{'workflow-action': true,
                           'disable-link':workflowListItem.state===states.DISABLED}"
             >
-
-              <app-nav-item-icon [workflowStats]="workflowListItem"></app-nav-item-icon>
+              <app-nav-item-icon [workflowMeta]="workflowListItem"></app-nav-item-icon>
                <div><strong *ngIf="workflowListItem.is_review">{{workflowListItem.display_name}}</strong>
                  <span *ngIf="! workflowListItem.is_review">{{workflowListItem.display_name}}</span>
                  <span></span>

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -8,7 +8,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {
   mockStudies,
   mockWorkflowSpecCategories,
-  mockWorkflowStats0, mockWorkflowStats1,
+  mockWorkflowMeta0, mockWorkflowMeta1,
   WorkflowState,
   WorkflowStatus
 } from 'sartography-workflow-lib';
@@ -49,22 +49,22 @@ describe('DashboardComponent', () => {
   });
 
   it('should get state label', () => {
-    mockWorkflowStats0.state = null;
-    expect(component.getStateLabel(mockWorkflowStats0)).toBeUndefined();
+    mockWorkflowMeta0.state = null;
+    expect(component.getStateLabel(mockWorkflowMeta0)).toBeUndefined();
 
     Object.keys(WorkflowState).forEach(k => {
-      mockWorkflowStats0.state = WorkflowState[k];
-      expect(component.getStateLabel(mockWorkflowStats0)).toBeDefined();
+      mockWorkflowMeta0.state = WorkflowState[k];
+      expect(component.getStateLabel(mockWorkflowMeta0)).toBeDefined();
     });
   });
 
   it('should get status label', () => {
-    mockWorkflowStats1.status = null;
-    expect(component.getStatusLabel(mockWorkflowStats1)).toBeUndefined();
+    mockWorkflowMeta1.status = null;
+    expect(component.getStatusLabel(mockWorkflowMeta1)).toBeUndefined();
 
     Object.keys(WorkflowStatus).forEach(k => {
-      mockWorkflowStats1.status = WorkflowStatus[k];
-      expect(component.getStatusLabel(mockWorkflowStats1)).toBeDefined();
+      mockWorkflowMeta1.status = WorkflowStatus[k];
+      expect(component.getStatusLabel(mockWorkflowMeta1)).toBeDefined();
     });
   });
 });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,7 +1,13 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
-import {isNumberDefined, Study, WorkflowSpecCategory, WorkflowState, WorkflowStatus,} from 'sartography-workflow-lib';
-import {WorkflowStats} from 'sartography-workflow-lib/lib/types/stats';
+import {
+  isNumberDefined,
+  Study,
+  WorkflowMetadata,
+  WorkflowSpecCategory,
+  WorkflowState,
+  WorkflowStatus,
+} from 'sartography-workflow-lib';
 import {shouldDisplayWorkflow} from '../_util/nav-item';
 
 
@@ -37,17 +43,8 @@ export class DashboardComponent implements OnInit {
   }
 
 
-  requiredItem(wf: WorkflowStats): boolean{
+  requiredItem(wf: WorkflowMetadata): boolean{
     return ((wf.state === WorkflowState.REQUIRED)||(wf.state === WorkflowState.DISABLED));
-  }
-
-  assignRandomStuff(wf: WorkflowStats) : WorkflowStats{
-    const enums : WorkflowState[] = [WorkflowState.DISABLED,WorkflowState.HIDDEN,WorkflowState.REQUIRED,WorkflowState.OPTIONAL];
-    const mystate = enums[Math.floor(Math.random() * enums.length)];
-    console.log(mystate);
-    wf.message = mystate;
-    wf.state = mystate;
-    return wf;
   }
 
   ngOnInit() {
@@ -87,7 +84,7 @@ export class DashboardComponent implements OnInit {
     return `${statusLabel} (${stateLabel})`
   }
 
-  getStatusLabel(workflow: WorkflowStats) {
+  getStatusLabel(workflow: WorkflowMetadata) {
     switch (workflow.status) {
       case WorkflowStatus.NOT_STARTED:
         return 'Not started';
@@ -102,7 +99,7 @@ export class DashboardComponent implements OnInit {
     }
   }
 
-  getStateLabel(workflow: WorkflowStats) {
+  getStateLabel(workflow: WorkflowMetadata) {
     switch (workflow.state) {
       case WorkflowState.HIDDEN:
         return '';
@@ -153,7 +150,7 @@ export class DashboardComponent implements OnInit {
     }
   }
 
-  workflowsToShow(workflowListItems: WorkflowStats[]) {
+  workflowsToShow(workflowListItems: WorkflowMetadata[]) {
     return workflowListItems.filter(wf => shouldDisplayWorkflow(wf));
   }
 

--- a/src/app/nav-item-icon/nav-item-icon.component.spec.ts
+++ b/src/app/nav-item-icon/nav-item-icon.component.spec.ts
@@ -3,10 +3,9 @@ import {MatIconModule} from '@angular/material/icon';
 import createClone from 'rfdc';
 import {
   mockNav0, mockTaskEvent0,
-  mockWorkflowStats0, NavItemType, TaskEvent, WorkflowNavItem,
+  mockWorkflowMeta0, NavItemType, TaskEvent, WorkflowNavItem,
   WorkflowStatus,
   WorkflowTaskState,
-  WorkflowTaskType
 } from 'sartography-workflow-lib';
 import {NavItemIconComponent} from './nav-item-icon.component';
 
@@ -34,11 +33,11 @@ describe('NavItemIconComponent', () => {
 
   it('should get icons for all workflow statuses', () => {
     let numPassed = 0;
-    const workflowStats = createClone({circles: true})(mockWorkflowStats0);
+    const workflowMeta = createClone({circles: true})(mockWorkflowMeta0);
     const statuses = Object.values(WorkflowStatus);
-    component.workflowStats = workflowStats;
+    component.workflowMeta = workflowMeta;
     statuses.forEach(s => {
-      workflowStats.status = s;
+      workflowMeta.status = s;
       component.update_icon();
       expect(component.icon).toBeTruthy('no icon for ' + s);
       numPassed++;

--- a/src/app/nav-item-icon/nav-item-icon.component.ts
+++ b/src/app/nav-item-icon/nav-item-icon.component.ts
@@ -1,5 +1,11 @@
 import {Component, Input, OnChanges, OnInit} from '@angular/core';
-import {NavItemType, TaskEvent, WorkflowNavItem, WorkflowStats, WorkflowStatus} from 'sartography-workflow-lib';
+import {
+  NavItemType,
+  TaskEvent,
+  WorkflowMetadata,
+  WorkflowNavItem,
+  WorkflowStatus
+} from 'sartography-workflow-lib';
 
 @Component({
   selector: 'app-nav-item-icon',
@@ -9,7 +15,7 @@ import {NavItemType, TaskEvent, WorkflowNavItem, WorkflowStats, WorkflowStatus} 
 export class NavItemIconComponent implements OnInit, OnChanges {
   @Input() navItem: WorkflowNavItem;
   @Input() taskEvent: TaskEvent;
-  @Input() workflowStats: WorkflowStats;
+  @Input() workflowMeta: WorkflowMetadata;
 
   icon: string;
   css: string;
@@ -25,8 +31,8 @@ export class NavItemIconComponent implements OnInit, OnChanges {
   }
 
   update_icon(): void {
-    if (this.workflowStats) {
-      switch (this.workflowStats.status) {
+    if (this.workflowMeta) {
+      switch (this.workflowMeta.status) {
         case WorkflowStatus.COMPLETE:
           this.icon = 'check_circle';
           this.css = 'complete';

--- a/src/app/review-progress/review-progress.component.ts
+++ b/src/app/review-progress/review-progress.component.ts
@@ -25,14 +25,16 @@ export class ReviewProgressComponent implements OnInit {
     this.numTotalReviews = 0;
     this.percentComplete = 0;
     this.study.categories.forEach(cat => {
-      cat.workflows.forEach(wf => {
-        if (wf.is_review) {
-          if (wf.status === WorkflowStatus.COMPLETE) {
-            this.numCompletedReviews += 1;
+      if (cat.workflows) {
+        cat.workflows.forEach(wf => {
+          if (wf.is_review) {
+            if (wf.status === WorkflowStatus.COMPLETE) {
+              this.numCompletedReviews += 1;
+            }
+            this.numTotalReviews += 1;
           }
-          this.numTotalReviews += 1;
-        }
-      });
+        });
+      }
     });
 
     this.opacity = .0;

--- a/src/app/studies-dashboard/studies-dashboard.component.scss
+++ b/src/app/studies-dashboard/studies-dashboard.component.scss
@@ -19,10 +19,9 @@
   border-radius: 10px;
   padding: 1rem;
   border: 1px solid rgba(255,255,255,.5);
-  margin-bottom: 2rem;
+  margin: 0 auto 2rem auto;
   width: 50vw;
   height:440px;
-  margin:auto;
 }
 
 

--- a/src/app/study-progress/study-progress.component.ts
+++ b/src/app/study-progress/study-progress.component.ts
@@ -24,12 +24,14 @@ export class StudyProgressComponent implements OnInit {
     this.numTotalWorkflows = 0;
     this.percentComplete = 0;
     this.study.categories.forEach(cat => {
-      cat.workflows.forEach(wf => {
-        if (wf.status === WorkflowStatus.COMPLETE) {
-          this.numCompletedWorkflows += 1;
-        }
-        this.numTotalWorkflows += 1;
-      });
+      if (cat.workflows) {
+        cat.workflows.forEach(wf => {
+          if (wf.status === WorkflowStatus.COMPLETE) {
+            this.numCompletedWorkflows += 1;
+          }
+          this.numTotalWorkflows += 1;
+        });
+      }
     });
 
     if (this.numCompletedWorkflows > 0) {

--- a/src/app/study/study.component.ts
+++ b/src/app/study/study.component.ts
@@ -8,7 +8,7 @@ import {
   StudyStatusLabels,
   Study,
   Workflow,
-  WorkflowSpecCategory, WorkflowStats
+  WorkflowSpecCategory, WorkflowMetadata
 } from 'sartography-workflow-lib';
 
 @Component({
@@ -23,7 +23,7 @@ export class StudyComponent implements OnInit {
   selectedCategoryId: number;
   selectedCategory: WorkflowSpecCategory;
   selectedWorkflowId: number;
-  selectedWorkflow: WorkflowStats;
+  selectedWorkflow: WorkflowMetadata;
   shrink = shrink;
 
   constructor(


### PR DESCRIPTION
…etadata that were the exact some thing.  Removed the WorkflowStats, replacing it everwhere with WorkflowModel.  This will also allow the workflow.state_message that comes from the backend to properly display now.