### PR TITLE
Do not reload the workflow statuses (run the master soec) unless abso…

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,5 @@
 import {HttpClient} from 'protractor-http-client';
 import {AppPage} from './app.po';
-import {by, element} from "protractor";
 
 describe('Clinical Research Coordinator App', () => {
   let page: AppPage;

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,14 +1,16 @@
 import {HttpClient} from 'protractor-http-client';
 import {AppPage} from './app.po';
+import {by, element} from "protractor";
 
 describe('Clinical Research Coordinator App', () => {
   let page: AppPage;
-  let http: HttpClient;
-  let newStudyId: number;
+  let httpPB: HttpClient;
+  let httpCRC: HttpClient;
 
   beforeEach(() => {
     page = new AppPage();
-    http = new HttpClient('http://localhost:5001');
+    httpPB = new HttpClient('http://localhost:5001');
+    httpCRC = new HttpClient('http://localhost:5000');
   });
 
   it('should automatically sign-in and redirect to home screen', () => {
@@ -39,10 +41,8 @@ describe('Clinical Research Coordinator App', () => {
 
   it('should load new study from Protocol Builder', async () => {
     const numStudiesBefore = await page.getElements('.study-row').count();
-    newStudyId = Math.floor(Math.random() * 100000);
     // Add a new study to Protocol Builder.
-    http.post('/new_study', '' +
-      `STUDYID=${newStudyId}&` +
+    httpPB.post('/new_study', '' +
       `TITLE=${encodeURIComponent('New study title')}&` +
       `NETBADGEID=dhf8r&` +
       `DATE_MODIFIED=${encodeURIComponent(new Date().toISOString())}&` +
@@ -57,7 +57,7 @@ describe('Clinical Research Coordinator App', () => {
     ).catch(error => {
       console.error(error);
     });
-    http.failOnHttpError = false;
+    httpPB.failOnHttpError = false;
 
     // Reload the list of studies.
     await page.clickElement('#cta_reload_studies');
@@ -98,25 +98,6 @@ describe('Clinical Research Coordinator App', () => {
     expect(newRoute.slice(0, expectedRoute.length)).toEqual(expectedRoute);
   });
 
-/*
-  it('should delete test study from Protocol Builder', async () => {
-    page.clickAndExpectRoute('#nav_home', '/home');
-    const numStudiesBeforeDel = await page.getElements('.study-row').count();
-    http.post(`/del_study/${newStudyId}`,
-      `confirm=y`
-    ).catch(error => {
-      console.error(error);
-    });
-    http.failOnHttpError = false;
-
-    await page.clickElement('#cta_reload_studies');
-    await page.waitForNotVisible('.loading');
-    await page.waitForClickable('.study-row');
-
-    const numStudiesAfterDel = await page.getElements('.study-row').count();
-    expect(numStudiesAfterDel).toEqual(numStudiesBeforeDel);
-  });
-*/
 
     // TODO: CATCH 401/403 ERRORS AND VERIFY THAT THEY REDIRECT TO LOGIN
   // afterEach(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11688,9 +11688,9 @@
       "dev": true
     },
     "sartography-workflow-lib": {
-      "version": "0.0.460",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.460.tgz",
-      "integrity": "sha512-9NusB90aCKDhJt+JwHekuNOPFa+kSZStIwGcDN7t2ALKCHcjD6nXQdxRkYlwVdgqfaGC5Jst5oHrSz+3IQxU3g=="
+      "version": "0.0.468",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.468.tgz",
+      "integrity": "sha512-rNSpwyN9A1W2NKq4CbHvX68xHMAuPOo0e8hoYo6pdPLL8Ob/PA95csvgKNfdWIXPy3dwneq2owGW135sbXk6SA=="
     },
     "sass": {
       "version": "1.26.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ngx-page-scroll-core": "^7.0.4",
     "rfdc": "^1.3.0",
     "rxjs": "~6.5.4",
-    "sartography-workflow-lib": "0.0.460",
+    "sartography-workflow-lib": "0.0.468",
     "timeago.js": "^4.0.2",
     "ts-md5": "^1.2.7",
     "tslib": "^1.14.1",

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -20,7 +20,6 @@ import {shouldDisplayWorkflow} from '../_util/nav-item';
 
 export class DashboardComponent implements OnInit {
   @Input() study: Study;
-  @Output() workflowSelected = new EventEmitter<number>();
   @Input() selectedWorkflowId: number;
   categoryTabs: WorkflowSpecCategory[];
   statuses = WorkflowStatus;
@@ -57,21 +56,6 @@ export class DashboardComponent implements OnInit {
       const wfId = wfIdStr ? parseInt(wfIdStr, 10) : undefined;
       this.selectCategory(null, catId, wfId);
     });
-  }
-
-  workflowLabel(workflow) {
-    const stateLabel = this.getStateLabel(workflow);
-    const statusLabel = this.getStatusLabel(workflow);
-
-    if (workflow.state === WorkflowState.HIDDEN) {
-      return '';
-    }
-
-    if (workflow.state === WorkflowState.DISABLED) {
-      return 'Not available';
-    }
-
-    return `${statusLabel} (${stateLabel})`
   }
 
   getStatusLabel(workflow: WorkflowMetadata) {
@@ -140,10 +124,5 @@ export class DashboardComponent implements OnInit {
 
   allComplete(cat: WorkflowSpecCategory) {
     return cat.workflows.every(wf => wf.status === WorkflowStatus.COMPLETE);
-  }
-
-  selectWorkflow(workflowId: number) {
-    this.selectedWorkflowId = workflowId;
-    this.workflowSelected.emit(this.selectedWorkflowId);
   }
 }

--- a/src/app/study/study.component.html
+++ b/src/app/study/study.component.html
@@ -25,7 +25,6 @@
     *ngIf="allWorkflows.length > 0"
     [study]="study"
     [selectedWorkflowId]="selectedWorkflowId"
-    (workflowSelected)="selectWorkflow($event)"
   ></app-dashboard>
 
   <app-study-events

--- a/src/app/study/study.component.spec.ts
+++ b/src/app/study/study.component.spec.ts
@@ -63,7 +63,7 @@ describe('StudyComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    const sReq = httpMock.expectOne('apiRoot/study/0');
+    const sReq = httpMock.expectOne('apiRoot/study/0?update_status=true');
     expect(sReq.request.method).toEqual('GET');
     sReq.flush(mockStudy0);
     expect(component.study).toBeTruthy();

--- a/src/app/study/study.component.spec.ts
+++ b/src/app/study/study.component.spec.ts
@@ -92,18 +92,13 @@ describe('StudyComponent', () => {
 
   it('should select workflow', () => {
     const workflowId = component.study.categories[0].workflows[0].id;
-    const loadStudySpy = spyOn(component, 'loadStudy').and.stub();
     component.selectWorkflow(workflowId);
     expect(component.isWorkflowSelected).toBeTrue()
     expect(component.selectedWorkflowId).toEqual(workflowId);
-    expect(loadStudySpy).not.toHaveBeenCalled();
-
-    loadStudySpy.calls.reset();
 
     component.selectWorkflow(undefined);
     expect(component.isWorkflowSelected).toBeFalse()
     expect(component.selectedWorkflowId).toBeUndefined();
-    expect(loadStudySpy).toHaveBeenCalled();
   });
 
 });

--- a/src/app/study/study.component.ts
+++ b/src/app/study/study.component.ts
@@ -7,8 +7,7 @@ import {
   StudyStatus,
   StudyStatusLabels,
   Study,
-  Workflow,
-  WorkflowSpecCategory, WorkflowMetadata
+  Workflow
 } from 'sartography-workflow-lib';
 
 @Component({
@@ -20,10 +19,7 @@ export class StudyComponent implements OnInit {
   study: Study;
   allWorkflows: Workflow[] = [];
   loading = true;
-  selectedCategoryId: number;
-  selectedCategory: WorkflowSpecCategory;
   selectedWorkflowId: number;
-  selectedWorkflow: WorkflowMetadata;
   shrink = shrink;
 
   constructor(
@@ -31,7 +27,6 @@ export class StudyComponent implements OnInit {
     private router: Router,
     private api: ApiService,
   ) {
-    this.loadStudy();
   }
 
 
@@ -40,12 +35,16 @@ export class StudyComponent implements OnInit {
   }
 
   ngOnInit() {
+    console.log('Init Called');
+    this.loadStudy();
   }
 
   loadStudy() {
+    console.log('Loading Study ...');
     this.route.paramMap.subscribe(paramMap => {
       const studyId = parseInt(paramMap.get('study_id'), 10);
-      this.api.getStudy(studyId).subscribe(s => {
+      // On this rare occasion, we want to force a status check on all the workflows.
+      this.api.getStudy(studyId, true).subscribe(s => {
         this.study = s;
         this.allWorkflows = this.study.categories.reduce((accumulator, cat) => {
           return accumulator.concat(cat.workflows);
@@ -59,20 +58,7 @@ export class StudyComponent implements OnInit {
     return StudyStatusLabels[status.toUpperCase()];
   }
 
-  selectCategory(categoryId: number) {
-    this.selectedCategoryId = categoryId;
-
-    if (!isNumberDefined(categoryId)) {
-      this.selectWorkflow(undefined);
-      // this.loadStudy(); # this calls selectWorkflow which will call loadStudy anyhow . . .
-    }
-  }
-
   selectWorkflow(workflowId: number) {
     this.selectedWorkflowId = workflowId;
-
-    if (!isNumberDefined(workflowId)) {
-      this.loadStudy();
-    }
   }
 }

--- a/src/app/workflow-files/workflow-files.component.html
+++ b/src/app/workflow-files/workflow-files.component.html
@@ -1,4 +1,5 @@
 <h3>Files for this {{typeLabel}}</h3>
+<div *ngIf="directory">
 <em *ngIf="directory.length > 0">The following files were created or uploaded as a part of this {{typeLabel}}.</em>
 <em *ngIf="directory.length == 0">No files are currently associated with this {{typeLabel}}.</em>
 
@@ -36,7 +37,8 @@
   </mat-nested-tree-node>
 
 </mat-tree>
-
+</div>
+<app-loading *ngIf="!directory"></app-loading>
 
 <!--
 

--- a/src/app/workflow-files/workflow-files.component.spec.ts
+++ b/src/app/workflow-files/workflow-files.component.spec.ts
@@ -77,8 +77,8 @@ describe('WorkflowFilesComponent', () => {
 
     const f1Req = httpMock.expectOne(`apiRoot/file/${mockFileMeta0.id}/data`);
     const f1ReqHeaders = new HttpHeaders()
-      .append('last-modified', mockFileMeta0.file.lastModified.toString())
-      .append('content-type', mockFileMeta0.file.type);
+      .append('last-modified', mockFileMeta0.last_modified.toString())
+      .append('content-type', mockFileMeta0.type);
     f1Req.flush(new ArrayBuffer(8), {headers: f1ReqHeaders});
     expect(f1Req.request.method).toEqual('GET');
 
@@ -89,8 +89,8 @@ describe('WorkflowFilesComponent', () => {
 
     const f2Req = httpMock.expectOne(`apiRoot/file/${mockFileMeta1.id}/data`);
     const f2ReqHeaders = new HttpHeaders()
-      .append('last-modified', mockFileMeta1.file.lastModified.toString())
-      .append('content-type', mockFileMeta1.file.type);
+      .append('last-modified', mockFileMeta1.last_modified.toString())
+      .append('content-type', mockFileMeta1.type);
     f2Req.flush(new ArrayBuffer(8), {headers: f2ReqHeaders});
     expect(f2Req.request.method).toEqual('GET');
     expect(msSaveOrOpenBlobSpy).toHaveBeenCalled();

--- a/src/app/workflow-files/workflow-files.component.ts
+++ b/src/app/workflow-files/workflow-files.component.ts
@@ -34,11 +34,13 @@ export class WorkflowFilesComponent implements OnInit,OnChanges,AfterViewInit {
   }
 
   expandNodes(nodes: DocumentDirectory[]): void{
-    nodes.forEach(node=>{
-      if (node.expanded) {
-        this.treeControl.expand(node);
-        this.expandNodes(node.children);
-      }});
+    if(nodes) {
+      nodes.forEach(node=>{
+        if (node.expanded) {
+          this.treeControl.expand(node);
+          this.expandNodes(node.children);
+        }});
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/workflow/workflow.component.spec.ts
+++ b/src/app/workflow/workflow.component.spec.ts
@@ -145,7 +145,7 @@ describe('WorkflowComponent', () => {
     wf1Req.flush(mockWorkflow0);
     expect(component.workflow).toEqual(mockWorkflow0);
 
-    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id);
+    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id + '?update_status=false');
     expect(sReq.request.method).toEqual('GET');
     sReq.flush(mockStudy0);
     expect(component.studyId).toEqual(mockStudy0.id);
@@ -410,7 +410,7 @@ describe('WorkflowComponent', () => {
     wf1Req.flush(mockWorkflow0);
     expect(component.workflow).toEqual(mockWorkflow0);
 
-    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id);
+    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id +  '?update_status=false');
     expect(sReq.request.method).toEqual('GET');
     sReq.flush(mockStudy0);
     expect(component.studyId).toEqual(mockStudy0.id);
@@ -439,7 +439,7 @@ describe('WorkflowComponent', () => {
     wf1Req.flush(mockWorkflow0);
     expect(component.workflow).toEqual(mockWorkflow0);
 
-    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id);
+    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id + '?update_status=false');
     expect(sReq.request.method).toEqual('GET');
     sReq.flush(mockStudy0);
     expect(component.studyId).toEqual(mockStudy0.id);
@@ -468,7 +468,7 @@ describe('WorkflowComponent', () => {
     wf1Req.flush(mockWorkflow0);
     expect(component.workflow).toEqual(mockWorkflow0);
 
-    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id);
+    const sReq = httpMock.expectOne('apiRoot/study/' + mockStudy0.id + '?update_status=false');
     expect(sReq.request.method).toEqual('GET');
     sReq.flush(mockStudy0);
     expect(component.studyId).toEqual(mockStudy0.id);


### PR DESCRIPTION
…lutely necessary (Just do it on the Study dashboard page, with a new api parameter of update_status=true)

Do not download the actual file when you are just looking for meta-data about the file.
Removing unused methods.
Metadata about a file, should not contain the actual file information.
Giving up on having the e2e tests delete the study it creates, but damn does it make a mess.