### PR TITLE
Fixes #591 - Nav not accessible after workflow is complete

### DIFF
--- a/src/app/workflow-progress-menu/workflow-progress-menu.component.html
+++ b/src/app/workflow-progress-menu/workflow-progress-menu.component.html
@@ -12,10 +12,16 @@
     You have no open tasks in this workflow at this time.
   </div>
 
-  <div *ngIf="completedTasks.length > 0">
+  <div *ngIf="completedTasks.length > 0 && readyTasks.length > 0">
     <h4 class="navHeading">Previously Completed</h4>
     <em>You may jump back in time to complete any of these tasks, but you will need to re-progress
       through this workflow in case the changes you make impact later steps.</em>
+    <ng-container *ngTemplateOutlet="navItemTemplate; context: {nav: completedTasks}"></ng-container>
+  </div>
+
+  <div *ngIf="completedTasks.length > 0 && readyTasks.length === 0">
+    <h4 class="navHeading">Previously Completed</h4>
+    <em> You have completed every task in this workflow. To restart, please use the 'Start over' button. </em>
     <ng-container *ngTemplateOutlet="navItemTemplate; context: {nav: completedTasks}"></ng-container>
   </div>
 

--- a/src/app/workflow-progress-menu/workflow-progress-menu.component.ts
+++ b/src/app/workflow-progress-menu/workflow-progress-menu.component.ts
@@ -65,6 +65,10 @@ export class WorkflowProgressMenuComponent implements OnInit, OnChanges {
   }
 
   selectable(navItem: WorkflowNavItem) {
+    // If the workflow is completed, lock the nav.
+    if (this.readyTasks.length == 0) {
+      return false;
+    }
     const isCurrent = this.isCurrent(navItem)
     return (navItem.state === WorkflowTaskState.READY ||
       navItem.state === WorkflowTaskState.COMPLETED) &&


### PR DESCRIPTION
Locks out the nav when you've completed all workflow tasks