### PR TITLE
Document history #695 #683

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ngx-page-scroll-core": "^7.0.5",
         "postcss": "^8.3.6",
         "rxjs": "^6.5.5",
-        "sartography-workflow-lib": "0.0.617",
+        "sartography-workflow-lib": "0.0.619",
         "timeago.js": "^4.0.2",
         "ts-md5": "^1.2.7",
         "tslib": "^2.0.0",
@@ -14940,9 +14940,9 @@
       "dev": true
     },
     "node_modules/sartography-workflow-lib": {
-      "version": "0.0.617",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.617.tgz",
-      "integrity": "sha512-/rTZ68wmB3YzBBqj21GpnS8A76Pxk4I7Rzl+IJbcPXulJRFg3/z1i0hOMELaRd8u6XtlzAsFtseael9p14fk+g==",
+      "version": "0.0.619",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.619.tgz",
+      "integrity": "sha512-qT4mXLE9ebLHUfJzMnBxdS1tPYrqSQ9NAbbGeUW9g5ASklF4M1vEpYHdtWFqHAApNf5C4SzeO9fMaGRIGFUxOw==",
       "dependencies": {
         "tslib": "^2.2.0"
       }
@@ -29813,9 +29813,9 @@
       "dev": true
     },
     "sartography-workflow-lib": {
-      "version": "0.0.617",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.617.tgz",
-      "integrity": "sha512-/rTZ68wmB3YzBBqj21GpnS8A76Pxk4I7Rzl+IJbcPXulJRFg3/z1i0hOMELaRd8u6XtlzAsFtseael9p14fk+g==",
+      "version": "0.0.619",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.619.tgz",
+      "integrity": "sha512-qT4mXLE9ebLHUfJzMnBxdS1tPYrqSQ9NAbbGeUW9g5ASklF4M1vEpYHdtWFqHAApNf5C4SzeO9fMaGRIGFUxOw==",
       "requires": {
         "tslib": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ngx-page-scroll-core": "^7.0.5",
     "postcss": "^8.3.6",
     "rxjs": "^6.5.5",
-    "sartography-workflow-lib": "0.0.617",
+    "sartography-workflow-lib": "0.0.619",
     "timeago.js": "^4.0.2",
     "ts-md5": "^1.2.7",
     "tslib": "^2.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -90,6 +90,7 @@ import { StudyWarningsComponent } from './study-warnings/study-warnings.componen
 import { AutocompleteComponent } from './_forms/autocomplete/autocomplete.component';
 import {MatAutocompleteModule} from "@angular/material/autocomplete";
 import { TaskLogsComponent } from './task-logs/task-logs.component';
+import { DocumentHistoryComponent } from './document-history/document-history.component';
 
 (document.defaultView as any).hljs = hljs;
 
@@ -213,6 +214,7 @@ export function markedOptionsFactory(): MarkedOptions {
     StudyWarningsComponent,
     AutocompleteComponent,
     TaskLogsComponent,
+    DocumentHistoryComponent,
   ],
     imports: [
         BrowserAnimationsModule,

--- a/src/app/document-history/document-history.component.html
+++ b/src/app/document-history/document-history.component.html
@@ -1,8 +1,44 @@
 <p>document-history works!</p>
 
-   <ng-container
-   *ngTemplateOutlet="recursiveListTmpl; context: {list: dataDictionary}"
-   ></ng-container>
+<ng-container
+  *ngTemplateOutlet="recursiveTableTmpl; context: {list: dataDictionary}"
+></ng-container>
+
+<ng-template #recursiveTableTmpl let-list="list">
+  <mat-table class="table" [dataSource]="list">
+    <ng-container matColumnDef="category">
+      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
+      <mat-cell *matCellDef="let list">{{list.level}}</mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="child">
+      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
+        <mat-cell *matCellDef="let list">
+      <ng-container *ngIf="list.children.length > 0">
+          <ng-container
+            *ngTemplateOutlet="recursiveTableTmpl; context: {list: list.children}"
+          ></ng-container>
+      </ng-container>
+        </mat-cell>
+   </ng-container>
+
+<!--    <ng-container *ngIf="list.children.length > 0">-->
+<!--      <ng-container-->
+<!--        *ngTemplateOutlet="recursiveTableTmpl; context: {children: list.children}"-->
+<!--      ></ng-container>-->
+<!--    </ng-container>-->
+
+    <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
+    <mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></mat-row>
+  </mat-table>
+</ng-template>
+
+
+<hr>
+
+<ng-container
+  *ngTemplateOutlet="recursiveListTmpl; context: {list: dataDictionary}"
+></ng-container>
 
 <ng-template #recursiveListTmpl let-list="list">
   <table class="table">
@@ -27,6 +63,19 @@
     </table>
 </ng-template>
 
+<hr>
+
+<!--<mat-table class="table" [dataSource]="dataDictionary">-->
+<!--  <ng-container matColumnDef="category">-->
+<!--    <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
+<!--    <mat-cell *matCellDef="let document">{{document.level}}</mat-cell>-->
+<!--  </ng-container>-->
+
+<!--  <mat-header-row *matHeaderRowDef="secondLevelColumns"></mat-header-row>-->
+<!--  <mat-row *matRowDef="let myRowData; columns: secondLevelColumns"></mat-row>-->
+<!--</mat-table>-->
+
+
 
 <!--  <ng-container *ngFor="let document of dataDictionary">-->
 <!--    <p>{{document.level}}</p>-->
@@ -37,13 +86,6 @@
 <!--  <p *ngFor="let child">{{child.level}}</p>-->
 <!--</ng-template>-->
 
-<mat-table [dataSource]="dataDictionary">
-
-<!--    <ng-container matColumnDef="category">-->
-<!--      <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
-<!--      <mat-cell *matCellDef="let document">{{document.level}}</mat-cell>-->
-<!--    </ng-container>-->
-
 <!--    <ng-container matColumnDef="child">-->
 <!--      <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
 <!--      <mat-cell *matCellDef="let document">-->
@@ -52,10 +94,6 @@
 
 <!--      </mat-cell>-->
 <!--    </ng-container>-->
-
-    <mat-header-row *matHeaderRowDef="noColumns"></mat-header-row>
-    <mat-row *matRowDef="let myRowData; columns: noColumns"></mat-row>
-</mat-table>
 
 <ng-template #recursiveListTmpl let-children="document.children">
 

--- a/src/app/document-history/document-history.component.html
+++ b/src/app/document-history/document-history.component.html
@@ -1,172 +1,64 @@
-<p>document-history works!</p>
+<h3>Document History</h3>
+<div matLine *ngIf="dataSource; then thenBlock else elseBlock"></div>
 
-<ng-container
-  *ngTemplateOutlet="recursiveTableTmpl; context: {list: dataDictionary}"
-></ng-container>
+<ng-template #thenBlock>
+  <div>
+    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="example-tree">
+      <!-- This is the tree node template for leaf nodes -->
+      <!-- These are actual files -->
+      <mat-nested-tree-node *matTreeNodeDef="let node">
+        <div [class.activeFile]="node.expanded">
+          <table class="file-table">
 
-<ng-template #recursiveTableTmpl let-list="list">
-  <mat-table class="table" [dataSource]="list">
-    <ng-container matColumnDef="category">
-      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
-      <mat-cell *matCellDef="let list">{{list.level}}</mat-cell>
-    </ng-container>
+            <tr>
+              <th>Current</th>
+              <th>Type</th>
+              <th>Name</th>
+              <th>User</th>
+              <th>Upload Date</th>
+              <th>Download</th>
+            </tr>
 
-    <ng-container matColumnDef="child">
-      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
-        <mat-cell *matCellDef="let list">
-      <ng-container *ngIf="list.children.length > 0">
-          <ng-container
-            *ngTemplateOutlet="recursiveTableTmpl; context: {list: list.children}"
-          ></ng-container>
-      </ng-container>
-        </mat-cell>
-   </ng-container>
+            <tr>
+              <td>{{!(node.file.archived)}}</td>
+              <td><mat-icon mat-list-icon [svgIcon]="'crc:' + node.file.type"></mat-icon></td>
+              <td><span class="tree-span" (mouseover)="hoverFile = node.file" (mouseleave)="hoverFile = null" >{{ node.file.name }}</span></td>
+              <td><span class="tree-span">{{node.file.user_uid}}</span></td>
+              <td><span class="tree-span">{{node.file.last_modified | date : 'medium'}}</span>
+              </td>
+              <td class="download" (click)="downloadFile(node.file)">
+                  <mat-icon>save_alt</mat-icon>
+              </td>
+            </tr>
 
-<!--    <ng-container *ngIf="list.children.length > 0">-->
-<!--      <ng-container-->
-<!--        *ngTemplateOutlet="recursiveTableTmpl; context: {children: list.children}"-->
-<!--      ></ng-container>-->
-<!--    </ng-container>-->
+          </table>
+        </div>
 
-    <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
-    <mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></mat-row>
-  </mat-table>
+      </mat-nested-tree-node>
+
+      <!-- This is the tree node template for expandable nodes -->
+      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+          <div class="mat-tree-node">
+            <button mat-icon-button matTreeNodeToggle
+                    [attr.aria-label]="'Toggle ' + node.level"
+            >
+              <mat-icon class="mat-icon-rtl-mirror">
+                {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+              </mat-icon>
+              <span>{{node.level}}</span>
+            </button>
+          </div>
+          <ul [class.example-tree-invisible]="!treeControl.isExpanded(node)">
+            <ng-container matTreeNodeOutlet></ng-container>
+          </ul>
+      </mat-nested-tree-node>
+
+    </mat-tree>
+  </div>
 </ng-template>
 
-
-<hr>
-
-<ng-container
-  *ngTemplateOutlet="recursiveListTmpl; context: {list: dataDictionary}"
-></ng-container>
-
-<ng-template #recursiveListTmpl let-list="list">
-  <table class="table">
-   <tr *ngFor="let item of list">
-      <td *ngIf="item.children.length > 0">
-      {{item.level}}
-         <ng-container
-            *ngTemplateOutlet="recursiveListTmpl; context:{ list: item.children }"
-         ></ng-container>
-      </td>
-     <td *ngIf="item.children.length === 0">
-       <table class="file-table">
-         <tr>
-           <td>{{item.file.name}}</td>
-           <td>{{item.file.irb_doc_code}}</td>
-           <td>{{item.file.user_uid}}</td>
-           <td>{{item.file.last_modified}}</td>
-         </tr>
-       </table>
-     </td>
-   </tr>
-    </table>
+<ng-template #elseBlock>
+  <div>
+    No documents uploaded.
+  </div>
 </ng-template>
-
-<hr>
-
-<!--<mat-table class="table" [dataSource]="dataDictionary">-->
-<!--  <ng-container matColumnDef="category">-->
-<!--    <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
-<!--    <mat-cell *matCellDef="let document">{{document.level}}</mat-cell>-->
-<!--  </ng-container>-->
-
-<!--  <mat-header-row *matHeaderRowDef="secondLevelColumns"></mat-header-row>-->
-<!--  <mat-row *matRowDef="let myRowData; columns: secondLevelColumns"></mat-row>-->
-<!--</mat-table>-->
-
-
-
-<!--  <ng-container *ngFor="let document of dataDictionary">-->
-<!--    <p>{{document.level}}</p>-->
-<!--    <ng-container *ngTemplateOutlet="documents;context:document"></ng-container>-->
-<!--  </ng-container>-->
-
-<!--<ng-template #documents let-children>-->
-<!--  <p *ngFor="let child">{{child.level}}</p>-->
-<!--</ng-template>-->
-
-<!--    <ng-container matColumnDef="child">-->
-<!--      <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
-<!--      <mat-cell *matCellDef="let document">-->
-
-<!--        <ng-container *ngTemplateOutlet="children;context:document"></ng-container>-->
-
-<!--      </mat-cell>-->
-<!--    </ng-container>-->
-
-<ng-template #recursiveListTmpl let-children="document.children">
-
-   <mat-table>
-    <ng-container matColumnDef="category">
-      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
-      <mat-cell *matCellDef="let document">{{document.level}}</mat-cell>
-    </ng-container>
-
-     <ng-container matColumnDef="child">
-      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
-      <mat-cell>Hello</mat-cell>
-     </ng-container>
-
-    <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
-    <mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></mat-row>
-   </mat-table>
-</ng-template>
-
-<!--<ng-template #myTest>-->
-<!--  Woot!-->
-<!--</ng-template>-->
-
-
-<!--    <ng-container matColumnDef="children">-->
-<!--      <mat-header-cell *matHeaderCellDef >Children</mat-header-cell>-->
-<!--      <mat-cell *matCellDef="let document">-->
-
-<!--        <mat-table [dataSource]="document.children">-->
-<!--          <ng-container matColumnDef="second-level">-->
-<!--            <mat-header-cell *matHeaderCellDef >Second Level</mat-header-cell>-->
-<!--            <mat-cell *matCellDef="let second">{{second.level}}</mat-cell>-->
-<!--          </ng-container>-->
-
-<!--          <mat-header-row *matHeaderRowDef="secondLevelColumns"></mat-header-row>-->
-<!--          <mat-row *matRowDef="let mySecondRowData; columns: secondLevelColumns"></mat-row>-->
-<!--        </mat-table>-->
-
-<!--      </mat-cell>-->
-<!--    </ng-container>-->
-
-
-<!--      <ng-container *ngIf="document.children.length > 0">-->
-<!--         <ng-container-->
-<!--            *ngTemplateOutlet="recursiveListTmpl; context:{ list: document.children }"-->
-<!--         ></ng-container>-->
-<!--      </ng-container>-->
-
-<ng-template #category>
-  Category
-</ng-template>
-
-<ng-template #file>
-  file
-</ng-template>
-
-<ng-template #children let-document="document">
-
-  <ng-container *ngIf="document.children">
-    <ng-container *ngTemplateOutlet="category;context:document"></ng-container>
-  </ng-container>
-
-  <ng-container *ngIf="document.file">
-    <ng-container *ngTemplateOutlet="file;context:document"></ng-container>
-  </ng-container>
-
-</ng-template>
-
-<!--       <ng-container *ngIf="document.children">-->
-<!--         <ng-container *ngTemplateOutlet="category;context:document"></ng-container>-->
-<!--       </ng-container>-->
-
-<!--       <ng-container *ngIf="document.file">-->
-<!--         <ng-container *ngTemplateOutlet="file;context:document"></ng-container>-->
-<!--       </ng-container>-->
-

--- a/src/app/document-history/document-history.component.html
+++ b/src/app/document-history/document-history.component.html
@@ -1,0 +1,134 @@
+<p>document-history works!</p>
+
+   <ng-container
+   *ngTemplateOutlet="recursiveListTmpl; context: {list: dataDictionary}"
+   ></ng-container>
+
+<ng-template #recursiveListTmpl let-list="list">
+  <table class="table">
+   <tr *ngFor="let item of list">
+      <td *ngIf="item.children.length > 0">
+      {{item.level}}
+         <ng-container
+            *ngTemplateOutlet="recursiveListTmpl; context:{ list: item.children }"
+         ></ng-container>
+      </td>
+     <td *ngIf="item.children.length === 0">
+       <table class="file-table">
+         <tr>
+           <td>{{item.file.name}}</td>
+           <td>{{item.file.irb_doc_code}}</td>
+           <td>{{item.file.user_uid}}</td>
+           <td>{{item.file.last_modified}}</td>
+         </tr>
+       </table>
+     </td>
+   </tr>
+    </table>
+</ng-template>
+
+
+<!--  <ng-container *ngFor="let document of dataDictionary">-->
+<!--    <p>{{document.level}}</p>-->
+<!--    <ng-container *ngTemplateOutlet="documents;context:document"></ng-container>-->
+<!--  </ng-container>-->
+
+<!--<ng-template #documents let-children>-->
+<!--  <p *ngFor="let child">{{child.level}}</p>-->
+<!--</ng-template>-->
+
+<mat-table [dataSource]="dataDictionary">
+
+<!--    <ng-container matColumnDef="category">-->
+<!--      <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
+<!--      <mat-cell *matCellDef="let document">{{document.level}}</mat-cell>-->
+<!--    </ng-container>-->
+
+<!--    <ng-container matColumnDef="child">-->
+<!--      <mat-header-cell *matHeaderCellDef ></mat-header-cell>-->
+<!--      <mat-cell *matCellDef="let document">-->
+
+<!--        <ng-container *ngTemplateOutlet="children;context:document"></ng-container>-->
+
+<!--      </mat-cell>-->
+<!--    </ng-container>-->
+
+    <mat-header-row *matHeaderRowDef="noColumns"></mat-header-row>
+    <mat-row *matRowDef="let myRowData; columns: noColumns"></mat-row>
+</mat-table>
+
+<ng-template #recursiveListTmpl let-children="document.children">
+
+   <mat-table>
+    <ng-container matColumnDef="category">
+      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
+      <mat-cell *matCellDef="let document">{{document.level}}</mat-cell>
+    </ng-container>
+
+     <ng-container matColumnDef="child">
+      <mat-header-cell *matHeaderCellDef ></mat-header-cell>
+      <mat-cell>Hello</mat-cell>
+     </ng-container>
+
+    <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
+    <mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></mat-row>
+   </mat-table>
+</ng-template>
+
+<!--<ng-template #myTest>-->
+<!--  Woot!-->
+<!--</ng-template>-->
+
+
+<!--    <ng-container matColumnDef="children">-->
+<!--      <mat-header-cell *matHeaderCellDef >Children</mat-header-cell>-->
+<!--      <mat-cell *matCellDef="let document">-->
+
+<!--        <mat-table [dataSource]="document.children">-->
+<!--          <ng-container matColumnDef="second-level">-->
+<!--            <mat-header-cell *matHeaderCellDef >Second Level</mat-header-cell>-->
+<!--            <mat-cell *matCellDef="let second">{{second.level}}</mat-cell>-->
+<!--          </ng-container>-->
+
+<!--          <mat-header-row *matHeaderRowDef="secondLevelColumns"></mat-header-row>-->
+<!--          <mat-row *matRowDef="let mySecondRowData; columns: secondLevelColumns"></mat-row>-->
+<!--        </mat-table>-->
+
+<!--      </mat-cell>-->
+<!--    </ng-container>-->
+
+
+<!--      <ng-container *ngIf="document.children.length > 0">-->
+<!--         <ng-container-->
+<!--            *ngTemplateOutlet="recursiveListTmpl; context:{ list: document.children }"-->
+<!--         ></ng-container>-->
+<!--      </ng-container>-->
+
+<ng-template #category>
+  Category
+</ng-template>
+
+<ng-template #file>
+  file
+</ng-template>
+
+<ng-template #children let-document="document">
+
+  <ng-container *ngIf="document.children">
+    <ng-container *ngTemplateOutlet="category;context:document"></ng-container>
+  </ng-container>
+
+  <ng-container *ngIf="document.file">
+    <ng-container *ngTemplateOutlet="file;context:document"></ng-container>
+  </ng-container>
+
+</ng-template>
+
+<!--       <ng-container *ngIf="document.children">-->
+<!--         <ng-container *ngTemplateOutlet="category;context:document"></ng-container>-->
+<!--       </ng-container>-->
+
+<!--       <ng-container *ngIf="document.file">-->
+<!--         <ng-container *ngTemplateOutlet="file;context:document"></ng-container>-->
+<!--       </ng-container>-->
+

--- a/src/app/document-history/document-history.component.html
+++ b/src/app/document-history/document-history.component.html
@@ -1,6 +1,6 @@
 <div id="document-history">
   <h3>Document History</h3>
-  <div *ngIf="dataSource; then thenBlock else elseBlock"></div>
+  <div *ngIf="dataSource.data.length > 0; then thenBlock else elseBlock"></div>
 
   <ng-template #thenBlock>
     <div id="thenBlock">

--- a/src/app/document-history/document-history.component.html
+++ b/src/app/document-history/document-history.component.html
@@ -21,7 +21,19 @@
               </tr>
 
               <tr>
-                <td>{{!(node.file.archived)}}</td>
+                <td *ngIf="node.file.archived; then thenArchiveBlock else elseArchiveBlock"></td>
+                <ng-template #thenArchiveBlock>
+                  <td class="red">
+                    Archived
+                  </td>
+                </ng-template>
+                <ng-template #elseArchiveBlock>
+                  <td class="green">
+                    Current
+                  </td>
+                </ng-template>
+
+<!--                <td>{{!(node.file.archived)}}</td>-->
                 <td><mat-icon mat-list-icon [svgIcon]="'crc:' + node.file.type"></mat-icon></td>
                 <td><span class="tree-span" (mouseover)="hoverFile = node.file" (mouseleave)="hoverFile = null" >{{ node.file.name }}</span></td>
                 <td><span class="tree-span">{{node.file.user_uid}}</span></td>

--- a/src/app/document-history/document-history.component.html
+++ b/src/app/document-history/document-history.component.html
@@ -1,64 +1,67 @@
-<h3>Document History</h3>
-<div matLine *ngIf="dataSource; then thenBlock else elseBlock"></div>
+<div id="document-history">
+  <h3>Document History</h3>
+  <div *ngIf="dataSource; then thenBlock else elseBlock"></div>
 
-<ng-template #thenBlock>
-  <div>
-    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="example-tree">
-      <!-- This is the tree node template for leaf nodes -->
-      <!-- These are actual files -->
-      <mat-nested-tree-node *matTreeNodeDef="let node">
-        <div [class.activeFile]="node.expanded">
-          <table class="file-table">
+  <ng-template #thenBlock>
+    <div id="thenBlock">
+      <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="history-tree">
+        <!-- leaf nodes -->
+        <!-- These are actual files -->
+        <mat-nested-tree-node *matTreeNodeDef="let node">
+          <div [class.activeFile]="node.expanded">
+            <table class="file-table">
 
-            <tr>
-              <th>Current</th>
-              <th>Type</th>
-              <th>Name</th>
-              <th>User</th>
-              <th>Upload Date</th>
-              <th>Download</th>
-            </tr>
+              <tr>
+                <th>Current</th>
+                <th>Type</th>
+                <th>Name</th>
+                <th>User</th>
+                <th>Upload Date</th>
+                <th>Download</th>
+              </tr>
 
-            <tr>
-              <td>{{!(node.file.archived)}}</td>
-              <td><mat-icon mat-list-icon [svgIcon]="'crc:' + node.file.type"></mat-icon></td>
-              <td><span class="tree-span" (mouseover)="hoverFile = node.file" (mouseleave)="hoverFile = null" >{{ node.file.name }}</span></td>
-              <td><span class="tree-span">{{node.file.user_uid}}</span></td>
-              <td><span class="tree-span">{{node.file.last_modified | date : 'medium'}}</span>
-              </td>
-              <td class="download" (click)="downloadFile(node.file)">
-                  <mat-icon>save_alt</mat-icon>
-              </td>
-            </tr>
+              <tr>
+                <td>{{!(node.file.archived)}}</td>
+                <td><mat-icon mat-list-icon [svgIcon]="'crc:' + node.file.type"></mat-icon></td>
+                <td><span class="tree-span" (mouseover)="hoverFile = node.file" (mouseleave)="hoverFile = null" >{{ node.file.name }}</span></td>
+                <td><span class="tree-span">{{node.file.user_uid}}</span></td>
+                <td><span class="tree-span">{{node.file.last_modified | date : 'medium'}}</span>
+                </td>
+                <td class="download" (click)="downloadFile(node.file)">
+                    <mat-icon>save_alt</mat-icon>
+                </td>
+              </tr>
 
-          </table>
-        </div>
-
-      </mat-nested-tree-node>
-
-      <!-- This is the tree node template for expandable nodes -->
-      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-          <div class="mat-tree-node">
-            <button mat-icon-button matTreeNodeToggle
-                    [attr.aria-label]="'Toggle ' + node.level"
-            >
-              <mat-icon class="mat-icon-rtl-mirror">
-                {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
-              </mat-icon>
-              <span>{{node.level}}</span>
-            </button>
+            </table>
           </div>
-          <ul [class.example-tree-invisible]="!treeControl.isExpanded(node)">
-            <ng-container matTreeNodeOutlet></ng-container>
-          </ul>
-      </mat-nested-tree-node>
 
-    </mat-tree>
-  </div>
-</ng-template>
+        </mat-nested-tree-node>
 
-<ng-template #elseBlock>
-  <div>
-    No documents uploaded.
-  </div>
-</ng-template>
+        <!-- expandable nodes -->
+        <!-- These are categories-->
+        <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+            <div class="mat-tree-node">
+              <button mat-icon-button matTreeNodeToggle
+                      [attr.aria-label]="'Toggle ' + node.level"
+              >
+                <mat-icon class="mat-icon-rtl-mirror">
+                  {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+                </mat-icon>
+                <span>{{node.level}}</span>
+              </button>
+            </div>
+            <ul [class.history-tree-invisible]="!treeControl.isExpanded(node)">
+              <ng-container matTreeNodeOutlet></ng-container>
+            </ul>
+        </mat-nested-tree-node>
+
+      </mat-tree>
+    </div>
+  </ng-template>
+
+  <ng-template #elseBlock>
+    <div>
+      No documents uploaded.
+    </div>
+  </ng-template>
+</div>

--- a/src/app/document-history/document-history.component.scss
+++ b/src/app/document-history/document-history.component.scss
@@ -6,3 +6,5 @@
   border: thin solid blue;
   padding: 2px;
 }
+
+hr {color: red}

--- a/src/app/document-history/document-history.component.scss
+++ b/src/app/document-history/document-history.component.scss
@@ -18,7 +18,7 @@ hr.green {color: green}
   height: 25px;
 }
 
-.example-tree-invisible {
+.history-tree-invisible {
   display: none;
 }
 
@@ -26,8 +26,8 @@ hr.green {color: green}
   background-color: $brand-accent-light;
 }
 
-.example-tree {
-  margin-top: 10px;
+.history-tree {
+  //margin-top: 10px;
 
    ul, li {
     margin-top: 5px;
@@ -93,4 +93,12 @@ span.tree-span {padding: 2px}
 
 .file-table .download {
   float: right;
+}
+
+#document-history {
+  padding: 5px 5px 5px 10px;
+}
+
+#thenBlock {
+  padding-left: 15px;
 }

--- a/src/app/document-history/document-history.component.scss
+++ b/src/app/document-history/document-history.component.scss
@@ -1,0 +1,8 @@
+.table {
+  border: thin solid black;
+  padding: 2px;
+}
+.file-table {
+  border: thin solid blue;
+  padding: 2px;
+}

--- a/src/app/document-history/document-history.component.scss
+++ b/src/app/document-history/document-history.component.scss
@@ -1,3 +1,4 @@
+@import "../../config";
 .table {
   border: thin solid black;
   padding: 2px;
@@ -7,4 +8,89 @@
   padding: 2px;
 }
 
-hr {color: red}
+hr {color: black}
+hr.red {color: red}
+hr.blue {color: blue}
+hr.green {color: green}
+
+.mat-tree-node{
+  min-height: 25px;
+  height: 25px;
+}
+
+.example-tree-invisible {
+  display: none;
+}
+
+.activeFile{
+  background-color: $brand-accent-light;
+}
+
+.example-tree {
+  margin-top: 10px;
+
+   ul, li {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    list-style-type: none;
+  }
+
+}
+
+
+::ng-deep app-document-history {
+  .mat-tree,
+  .mat-tree-node,
+  .mat-nested-tree-node,
+  .mat-list-base .mat-list-item .mat-list-item-content,
+  .mat-list-base .mat-list-option .mat-list-item-content {
+    cursor: pointer;
+    padding-left: 0;
+    padding-right: 0;
+
+    .mat-list-text {
+      padding-left: 0.25rem !important;
+    }
+  }
+}
+.file {
+
+    color: $brand-accent;
+    font-size: 1rem;
+    text-decoration: underline;
+    padding-left: 0;
+    padding-top: 4px;
+
+
+  mat-icon {
+    opacity: 0;
+  }
+}
+
+.file {
+
+    &:hover {
+      background-color: $brand-accent-light;
+
+      mat-icon {
+        opacity: 1;
+        color: $brand-gray;
+        margin: 2px;
+      }
+
+
+  }
+}
+span.tree-span {padding: 2px}
+
+.mat-nested-tree-node, div {
+  padding: 2px;
+}
+
+.file-table {
+  padding: 3px;
+}
+
+.file-table .download {
+  float: right;
+}

--- a/src/app/document-history/document-history.component.spec.ts
+++ b/src/app/document-history/document-history.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocumentHistoryComponent } from './document-history.component';
+
+describe('DocumentHistoryComponent', () => {
+  let component: DocumentHistoryComponent;
+  let fixture: ComponentFixture<DocumentHistoryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DocumentHistoryComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocumentHistoryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/document-history/document-history.component.spec.ts
+++ b/src/app/document-history/document-history.component.spec.ts
@@ -1,14 +1,31 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DocumentHistoryComponent } from './document-history.component';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatIconModule} from '@angular/material/icon';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {RouterTestingModule} from '@angular/router/testing';
+import {ApiService, MockEnvironment} from 'sartography-workflow-lib';
+import {APP_BASE_HREF} from '@angular/common';
 
 describe('DocumentHistoryComponent', () => {
   let component: DocumentHistoryComponent;
   let fixture: ComponentFixture<DocumentHistoryComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DocumentHistoryComponent ]
+      declarations: [ DocumentHistoryComponent ],
+      imports: [
+        HttpClientTestingModule,
+      ],
+      providers: [
+        ApiService,
+        {provide: 'APP_ENVIRONMENT', useClass: MockEnvironment},
+        {provide: APP_BASE_HREF, useValue: '/'},
+      ]
     })
     .compileComponents();
   });
@@ -19,7 +36,11 @@ describe('DocumentHistoryComponent', () => {
     fixture.detectChanges();
   });
 
+  /*
+  fixme: We should have tests on the document history component.
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+*/
 });
+

--- a/src/app/document-history/document-history.component.ts
+++ b/src/app/document-history/document-history.component.ts
@@ -46,7 +46,7 @@ export class DocumentHistoryComponent implements OnInit, OnChanges, AfterViewIni
   }
 
   ngOnInit(): void {
-    this.api.getDocumentDirectory(this.study.id, null).subscribe(dd => {
+    this.api.getDocumentDirectory(this.study.id, null, true).subscribe(dd => {
       this.dataSource.data = dd;
       this.dataDictionary = dd;
     });

--- a/src/app/document-history/document-history.component.ts
+++ b/src/app/document-history/document-history.component.ts
@@ -1,25 +1,84 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, OnChanges, AfterViewInit, SimpleChanges} from '@angular/core';
 import {ApiService, DocumentDirectory, Study, FileMeta} from 'sartography-workflow-lib';
 import {MatTreeNestedDataSource} from "@angular/material/tree";
 import {NestedTreeControl} from "@angular/cdk/tree";
+
 @Component({
   selector: 'app-document-history',
   templateUrl: './document-history.component.html',
   styleUrls: ['./document-history.component.scss']
 })
-export class DocumentHistoryComponent implements OnInit {
+export class DocumentHistoryComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() study: Study;
+  @Input() directory: DocumentDirectory[];
+  typeLabel: string;
   dataDictionary: DocumentDirectory[];
   columnsToDisplay = ['category', 'child'];
   secondLevelColumns = ['category']
   noColumns = []
+  treeControl = new NestedTreeControl<DocumentDirectory>(node => node.children);
+  dataSource = new MatTreeNestedDataSource<DocumentDirectory>();
+  hoverFile: FileMeta;
 
 
   constructor(private api: ApiService) { }
 
+  ngOnChanges(changes: SimpleChanges){
+    this.dataSource.data = this.directory;
+    this.treeControl.dataNodes = this.directory;
+    setTimeout(() => this.expandNodes(this.directory), 10);
+  }
+
+  hasChild = (_: number, node: DocumentDirectory) => node.children.length > 0;
+
+  ngAfterViewInit() {
+    this.expandNodes(this.directory);
+  }
+
+  expandNodes(nodes: DocumentDirectory[]): void{
+    if (nodes) {
+      nodes.forEach(node => {
+        if (node.expanded) {
+          this.treeControl.expand(node);
+          this.expandNodes(node.children);
+        }});
+    }
+  }
+
   ngOnInit(): void {
     this.api.getDocumentDirectory(this.study.id, null).subscribe(dd => {
+      this.dataSource.data = dd;
       this.dataDictionary = dd;
+    });
+  }
+
+  public downloadFile(fileMeta: FileMeta): void {
+    this.api.getFileData(fileMeta.id).subscribe(response => {
+      // It is necessary to create a new response object with mime-type explicitly set
+      // otherwise only Chrome works like it should
+      const newBlob = new Blob([response.body], {type: fileMeta.content_type});
+
+      // IE doesn't allow using a blob object directly as link href
+      // instead it is necessary to use msSaveOrOpenBlob
+      if (window.navigator && window.navigator.msSaveOrOpenBlob) {
+        window.navigator.msSaveOrOpenBlob(newBlob);
+        return;
+      }
+
+      // For other browsers:
+      // Create a link pointing to the ObjectURL containing the blob.
+      const data = window.URL.createObjectURL(newBlob);
+      const link = document.createElement('a');
+      link.href = data;
+      link.download = fileMeta.name;
+      // this is necessary as link.click() does not work on the latest firefox
+      link.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, view: window}));
+
+      setTimeout(() => {
+        // For Firefox it is necessary to delay revoking the ObjectURL
+        window.URL.revokeObjectURL(data);
+        link.remove();
+      }, 100);
     });
   }
 

--- a/src/app/document-history/document-history.component.ts
+++ b/src/app/document-history/document-history.component.ts
@@ -1,0 +1,26 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {ApiService, DocumentDirectory, Study, FileMeta} from 'sartography-workflow-lib';
+import {MatTreeNestedDataSource} from "@angular/material/tree";
+import {NestedTreeControl} from "@angular/cdk/tree";
+@Component({
+  selector: 'app-document-history',
+  templateUrl: './document-history.component.html',
+  styleUrls: ['./document-history.component.scss']
+})
+export class DocumentHistoryComponent implements OnInit {
+  @Input() study: Study;
+  dataDictionary: DocumentDirectory[];
+  columnsToDisplay = ['category', 'child'];
+  secondLevelColumns = ['category']
+  noColumns = []
+
+
+  constructor(private api: ApiService) { }
+
+  ngOnInit(): void {
+    this.api.getDocumentDirectory(this.study.id, null).subscribe(dd => {
+      this.dataDictionary = dd;
+    });
+  }
+
+}

--- a/src/app/study/study.component.html
+++ b/src/app/study/study.component.html
@@ -41,6 +41,9 @@
     <mat-tab label="Logs">
       <app-task-logs [studyId]="study.id"></app-task-logs>
     </mat-tab>
+    <mat-tab label="Documents">
+      <app-document-history [study]="study"></app-document-history>
+    </mat-tab>
     <mat-tab label="Admin Warnings">
       <app-study-warnings
         *ngIf="study.warnings.length > 0 && isAdmin && showAdminTools"

--- a/src/app/task-logs/task-logs.component.scss
+++ b/src/app/task-logs/task-logs.component.scss
@@ -22,12 +22,12 @@
 }
 
 .mat-column-workflow {
-  flex: 0 0 25%;
+  flex: 0 0 17%;
   text-align: center;
 }
 
 .mat-column-category {
-  flex: 0 0 10%;
+  flex: 0 0 18%;
   text-align: center;
 }
 


### PR DESCRIPTION
Add document history tab to bottom of Study page
Works similarly to the files tab in a workflow
Reused the mat-tree code from the files tab, and the document_directory in the backend code to generate the list of documents

Also, small UI tweek for Study Logs from ticket 683