### PR TITLE
Unlock admin sandbox #739

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "ngx-page-scroll-core": "^7.0.6",
         "postcss": "^8.3.6",
         "rxjs": "^6.5.5",
-        "sartography-workflow-lib": "0.0.621",
+        "sartography-workflow-lib": "0.0.623",
         "timeago.js": "^4.0.2",
         "ts-md5": "^1.2.7",
         "tslib": "^2.0.0",
@@ -15118,9 +15118,9 @@
       "dev": true
     },
     "node_modules/sartography-workflow-lib": {
-      "version": "0.0.621",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.621.tgz",
-      "integrity": "sha512-Mj78eIyOPMBaqR4IcGWz6/7GFFHgLnBB0zl+i/x6ZFbBY9xn04OUoiLqXRK/yt2/SRqaDkM90PQ/HHqqF1DDLQ==",
+      "version": "0.0.623",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.623.tgz",
+      "integrity": "sha512-4w39Yyb5a6YZr/aGqmk5ScjV+mb/TXxQX2bjwbgpXyTeuQL57WkbPrseYEwvdAG2Fc+BIg9Mtu4QHMXWIaXQIA==",
       "dependencies": {
         "tslib": "^2.2.0"
       }
@@ -30021,9 +30021,9 @@
       "dev": true
     },
     "sartography-workflow-lib": {
-      "version": "0.0.621",
-      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.621.tgz",
-      "integrity": "sha512-Mj78eIyOPMBaqR4IcGWz6/7GFFHgLnBB0zl+i/x6ZFbBY9xn04OUoiLqXRK/yt2/SRqaDkM90PQ/HHqqF1DDLQ==",
+      "version": "0.0.623",
+      "resolved": "https://registry.npmjs.org/sartography-workflow-lib/-/sartography-workflow-lib-0.0.623.tgz",
+      "integrity": "sha512-4w39Yyb5a6YZr/aGqmk5ScjV+mb/TXxQX2bjwbgpXyTeuQL57WkbPrseYEwvdAG2Fc+BIg9Mtu4QHMXWIaXQIA==",
       "requires": {
         "tslib": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ngx-page-scroll-core": "^7.0.6",
     "postcss": "^8.3.6",
     "rxjs": "^6.5.5",
-    "sartography-workflow-lib": "0.0.621",
+    "sartography-workflow-lib": "0.0.623",
     "timeago.js": "^4.0.2",
     "ts-md5": "^1.2.7",
     "tslib": "^2.0.0",

--- a/src/app/workflow/workflow.component.ts
+++ b/src/app/workflow/workflow.component.ts
@@ -340,6 +340,9 @@ export class WorkflowComponent implements OnInit {
 
   isLocked(currentTask: WorkflowTask): boolean {
     if (this.study) {
+      if (this.workflow.is_admin_workflow) {
+        return false;
+      }
       return this.study.status === 'abandoned' ||
         this.study.status === 'cr_connect_complete' ||
         this.study.status === 'hold' ||


### PR DESCRIPTION
Workflows in the admin sandbox should remain unlocked.

Normally, we want to lock studies--and their workflows, when the studies are **complete**, **abandoned**, or **on hold**.
But, not for workflows in the **admin sandbox**

Use the `is_admin_workflow` attribute to determine if a workflow is in an "admin sandbox" category.

 *** Requires changes from [Sartography Libraries PR 110](https://github.com/sartography/sartography-libraries/pull/110) ***